### PR TITLE
Refactor GenerateWeatherBatchData to reduce twice nested loop

### DIFF
--- a/dataGenerator/dataGenerator.Tests/Config/FileConfigTest.cs
+++ b/dataGenerator/dataGenerator.Tests/Config/FileConfigTest.cs
@@ -5,14 +5,23 @@ namespace dataGenerator.Tests.Config;
 
 public class FileConfigTest
 {
+    private const string ExpectedFilePath = "test/path/sample.txt";
+
     [Fact]
-    public void TestFileConfigSetter()
+    public void TestFileConfigConstructorSetter()
     {
-        const string expectedFilePath = "test/path/sample.txt";
         var fileConfig = new FileConfig
         {
-            FilePath = expectedFilePath
+            FilePath = ExpectedFilePath
         };
-        Assert.Equal(expectedFilePath, fileConfig.FilePath);
+        Assert.Equal(ExpectedFilePath, fileConfig.FilePath);
+    }
+
+    [Fact]
+    public void TestFileConfigVariableSetter()
+    {
+        var fileConfig = new FileConfig();
+        fileConfig.FilePath = ExpectedFilePath;
+        Assert.Equal(ExpectedFilePath, fileConfig.FilePath);
     }
 }

--- a/dataGenerator/dataGenerator.Tests/Data/WeatherData/WeatherModelTest.cs
+++ b/dataGenerator/dataGenerator.Tests/Data/WeatherData/WeatherModelTest.cs
@@ -7,10 +7,9 @@ namespace dataGenerator.Tests.Data.WeatherData;
 public class WeatherModelTest
 {
     [Fact]
-    public void TestWeatherModelSetter()
+    public void TestWeatherModelConstructorSetter()
     {
         // Arrange
-        var timestamp = new DateTime(2024, 6, 28, 12, 0, 0);
         const double longitude = 123.45;
         const double latitude = 54.32;
         const double temperatureValue = 25.5;
@@ -23,7 +22,6 @@ public class WeatherModelTest
         // Act
         var weatherModel = new WeatherModel
         {
-            Timestamp = timestamp,
             Longitude = longitude,
             Latitude = latitude,
             TemperatureValue = temperatureValue,
@@ -35,7 +33,6 @@ public class WeatherModelTest
         };
 
         // Assert
-        Assert.Equal(timestamp, weatherModel.Timestamp);
         Assert.Equal(longitude, weatherModel.Longitude);
         Assert.Equal(latitude, weatherModel.Latitude);
         Assert.Equal(temperatureValue, weatherModel.TemperatureValue);

--- a/dataGenerator/dataGenerator.Tests/Data/WeatherGeneratorTest.cs
+++ b/dataGenerator/dataGenerator.Tests/Data/WeatherGeneratorTest.cs
@@ -27,23 +27,17 @@ public class WeatherGeneratorTests
     [Fact]
     public void GenerateDataGenerate_Success()
     {
-        //Arrange
-        var expectedTimestampLower = _weatherConfig.StartTimestampUtc.Date.AddDays(-30);
-        var expectedTimestampUpper = _weatherConfig.StartTimestampUtc.Date.AddDays(+30);
-
         // Act
         var weatherModel = _weatherGenerator.GenerateData();
 
         // Assert
         Assert.NotNull(weatherModel);
-        Assert.True(
-            weatherModel.Timestamp >= expectedTimestampLower && weatherModel.Timestamp <= expectedTimestampUpper);
 
         Assert.InRange(weatherModel.Longitude, -180, 180);
         Assert.InRange(weatherModel.Latitude, -90, 90);
         AssertDecimalPlaces(_weatherConfig.Information.LongitudeDecimalPlaces, weatherModel.Longitude);
         AssertDecimalPlaces(_weatherConfig.Information.LatitudeDecimalPlaces, weatherModel.Latitude);
-        
+
         Assert.Contains(weatherModel.TemperatureUnit,
             _weatherConfig.Information.TemperatureUnit);
         if (weatherModel.TemperatureUnit == "C")
@@ -64,7 +58,7 @@ public class WeatherGeneratorTests
             _weatherConfig.Information
                 .PrecipitationChancePercentageUpperLimit);
     }
-    
+
     private void AssertDecimalPlaces(int expectedDecimalPlaces, double actual)
     {
         var valueStr = actual.ToString("0.###############");

--- a/dataGenerator/dataGenerator/Data/WeatherData/WeatherModel.cs
+++ b/dataGenerator/dataGenerator/Data/WeatherData/WeatherModel.cs
@@ -5,7 +5,6 @@
 /// </summary>
 public class WeatherModel
 {
-    public DateTime Timestamp { get; set; }
     public double Longitude { get; set; }
     public double Latitude { get; set; }
     public double TemperatureValue { get; set; }

--- a/dataGenerator/dataGenerator/Data/WeatherGenerator.cs
+++ b/dataGenerator/dataGenerator/Data/WeatherGenerator.cs
@@ -40,8 +40,8 @@ public class WeatherGenerator : IDataGenerator<WeatherModel>
     private Faker<WeatherModel> GenerateFakeWeather()
     {
         var randomizer = new Randomizer();
+        
         return new Faker<WeatherModel>()
-            .RuleFor(w => w.Timestamp, f => f.Date.RecentOffset(30).UtcDateTime)
             .RuleFor(w => w.Longitude,
                 f => Math.Round(randomizer.Double(-180, 180), _weatherConfig.Information.LongitudeDecimalPlaces))
             .RuleFor(w => w.Latitude,

--- a/dataGenerator/dataGenerator/Factory/WeatherFactory.cs
+++ b/dataGenerator/dataGenerator/Factory/WeatherFactory.cs
@@ -62,21 +62,10 @@ public class WeatherFactory : IDataFactory
 
         for (var i = 0; i < lengthOfHours; i++)
         {
-            var hourData = new List<WeatherModel>();
-
+            stringBuilder.AppendLine(startTimestamp.AddHours(i).ToString("yyyy-MM-dd HH:00UTC"));
             for (var j = 0; j < numberOfWeatherInformationRecords; j++)
             {
                 var weatherData = _dataGenerator.GenerateData();
-                // Adjust the timestamp to the specific hour we are iterating over
-                weatherData.Timestamp = startTimestamp.AddHours(i);
-                hourData.Add(weatherData);
-            }
-
-            var timestamp = hourData.First().Timestamp.ToString("yyyy-MM-dd HH:00UTC");
-            stringBuilder.AppendLine(timestamp);
-
-            foreach (var weatherData in hourData)
-            {
                 stringBuilder.AppendLine(
                     $"{weatherData.Longitude}" +
                     $"\t{weatherData.Latitude}" +

--- a/dataGenerator/dataGenerator/Factory/WeatherFactory.cs
+++ b/dataGenerator/dataGenerator/Factory/WeatherFactory.cs
@@ -45,7 +45,7 @@ public class WeatherFactory : IDataFactory
             lengthOfHours: _weatherConfig.WeatherTimestampQuantity,
             numberOfWeatherInformationRecords: _weatherConfig.NumberOfWeatherInformationRecords
         );
-        _fileWriter.WriteToFile(content, GetFileName());
+        _fileWriter.WriteToFile(content, _weatherConfig.FileName);
     }
 
     /// <summary>
@@ -79,11 +79,5 @@ public class WeatherFactory : IDataFactory
         }
 
         return stringBuilder.ToString();
-    }
-
-    private string GetFileName()
-    {
-        var fileName = _weatherConfig.FileName;
-        return string.IsNullOrEmpty(fileName) ? "WeatherData" : fileName;
     }
 }

--- a/dataGenerator/dataGenerator/Program.cs
+++ b/dataGenerator/dataGenerator/Program.cs
@@ -23,7 +23,7 @@ class Program
             .WriteTo.Console()
             .CreateLogger();
 
-        var host = Host.CreateDefaultBuilder()
+        using var host = Host.CreateDefaultBuilder()
             .ConfigureServices((context, services) =>
             {
                 services.Configure<WeatherConfig>(context.Configuration.GetSection("WeatherConfig"));
@@ -35,11 +35,11 @@ class Program
             .UseSerilog()
             .Build();
 
-        var svc = ActivatorUtilities.CreateInstance<WeatherFactory>(host.Services);
-        svc.Generate();
+        var svc = host.Services.GetService<IDataFactory>();
+        svc?.Generate();
     }
 
-    static void BuildConfig(IConfigurationBuilder builder)
+    private static void BuildConfig(IConfigurationBuilder builder)
     {
         builder.SetBasePath(Directory.GetCurrentDirectory())
             .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)


### PR DESCRIPTION
Reduce complexity of GenerateWeatherBatchData method, by removing twice nested for loop and removing unnecessary Timestamp from WeatherData model.

Remove unnecessary get file name method

Add using statement to host in program.cs as it is IDisposable. 

Refactor program main Generate call to use DI and instance of the Services GetService

Tests:
![image](https://github.com/JohnRMcCulloch/dataGenerator/assets/103056592/13ad9989-3c06-49d9-806b-77f29003fd0b)
![image](https://github.com/JohnRMcCulloch/dataGenerator/assets/103056592/75f2d9e3-76da-43c2-8ade-8f5b0b1af8ab)
